### PR TITLE
fix: prioritize fix endpoints in the withdrawal controller

### DIFF
--- a/docs/routes.ts
+++ b/docs/routes.ts
@@ -206,6 +206,7 @@ const models: TsoaRoute.Models = {
             "tokenSymbol": {"dataType":"string","required":true},
             "network": {"dataType":"string","required":true},
             "amount": {"dataType":"double","required":true},
+            "key": {"dataType":"string"},
         },
         "additionalProperties": false,
     },

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -493,6 +493,9 @@
 					"amount": {
 						"type": "number",
 						"format": "double"
+					},
+					"key": {
+						"type": "string"
 					}
 				},
 				"required": [
@@ -2838,6 +2841,14 @@
 						"schema": {
 							"format": "double",
 							"type": "number"
+						}
+					},
+					{
+						"in": "query",
+						"name": "key",
+						"required": false,
+						"schema": {
+							"type": "string"
 						}
 					}
 				]

--- a/src/routes/withdrawal.controller.ts
+++ b/src/routes/withdrawal.controller.ts
@@ -27,6 +27,7 @@ interface GetWithdrawalFeeParams {
   tokenSymbol: string;
   network: string;
   amount: number;
+  key?: string;
 }
 interface GetWhitelistedAddressesParams {
   tokenSymbol?: string;
@@ -151,7 +152,14 @@ export class WithdrawalController extends Controller {
     @Header('x-exchange-api-password') password?: string,
     @Header('x-exchange-api-uid') uid?: string,
   ): Promise<GetWithdrawalFeeResponse> {
-    return await this.sdk.api.getWithdrawalFee({ exchangeInstanceId, auth: { exchangeId, apiKey, secretKey, password, uid }, ...params });
+    return await this.sdk.api.getWithdrawalFee({ 
+      exchangeInstanceId, 
+      auth: { exchangeId, apiKey, secretKey, password, uid }, 
+      ...params, 
+      opts: {
+        key: params.key,
+      } 
+    });
   }
 
   /**
@@ -210,22 +218,6 @@ export function withdrawalRoutes(sdk: any) {
   const router = Router();
   const controller = new WithdrawalController(sdk);
 
-  router.get('/:withdrawalId', errorHandler(async (req, res) => {
-    const auth = extractAuthFromHeaders(req);
-    const result = await controller.getWithdrawalById(
-      req.params.withdrawalId,
-      req.query.tokenSymbol as string,
-      Number(req.query.timestamp),
-      auth.exchangeInstanceId,
-      auth.exchangeId,
-      auth.apiKey,
-      auth.secretKey,
-      auth.password,
-      auth.uid
-      );
-    res.json(result);
-  }));
-
   router.post('/', errorHandler(async (req, res) => {
     const result = await controller.createWithdrawal(req.body);
     res.json(result);
@@ -244,6 +236,7 @@ export function withdrawalRoutes(sdk: any) {
           tokenSymbol: req.query.tokenSymbol as string,
           network: req.query.network as string,
           amount: Number(req.query.amount),
+          key: req.query.key as string,
         },
         auth.exchangeInstanceId,
         auth.exchangeId,
@@ -289,6 +282,22 @@ export function withdrawalRoutes(sdk: any) {
         auth.uid,
       );
       res.json(result);
+  }));
+
+  router.get('/:withdrawalId', errorHandler(async (req, res) => {
+    const auth = extractAuthFromHeaders(req);
+    const result = await controller.getWithdrawalById(
+      req.params.withdrawalId,
+      req.query.tokenSymbol as string,
+      Number(req.query.timestamp),
+      auth.exchangeInstanceId,
+      auth.exchangeId,
+      auth.apiKey,
+      auth.secretKey,
+      auth.password,
+      auth.uid
+      );
+    res.json(result);
   }));
 
   return router;


### PR DESCRIPTION
The routing order caused the dynamic endpoint withdrawalById to be called every time the withdrawal controller was used, even when a different method should have been invoked. I modified the routing order to prioritize fixed routes over the dynamic one.