### PR TITLE
feat: add ip pool size config to increase requests throughput

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,6 +25,10 @@ CLIENT_ID=sdk-***
 # /!\ Make sure to add a slash at the end of the URL
 PROXY_URL=https://<your-proxy-url>/
 
+# The number of unique IPs in your proxy pool. This is used to scale the rate limits for exchanges
+# that limit by IP (like Binance). Default is 1.
+IP_POOL_SIZE=2
+
 # The port to run the server on
 APP_PORT=3000
 

--- a/docs/routes.ts
+++ b/docs/routes.ts
@@ -391,7 +391,7 @@ const models: TsoaRoute.Models = {
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     "CreateOrderRequest": {
         "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"metadata":{"dataType":"nestedObjectLiteral","nestedProperties":{"defiAddress":{"dataType":"string"},"tradeAndSend":{"dataType":"boolean"}}},"amount":{"dataType":"string","required":true},"price":{"dataType":"string","required":true},"orderType":{"ref":"OrderType","required":true},"orderSide":{"ref":"OrderSide","required":true},"pairSymbol":{"ref":"PairSymbol","required":true}},"validators":{}},
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"metadata":{"dataType":"nestedObjectLiteral","nestedProperties":{"defiAddress":{"dataType":"string"},"tradeAndSend":{"dataType":"boolean"}}},"recaptchaToken":{"dataType":"string"},"amount":{"dataType":"string","required":true},"price":{"dataType":"string","required":true},"orderType":{"ref":"OrderType","required":true},"orderSide":{"ref":"OrderSide","required":true},"pairSymbol":{"ref":"PairSymbol","required":true}},"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     "PreparedOrder": {
@@ -461,7 +461,7 @@ const models: TsoaRoute.Models = {
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     "Pick_CreateOrderParamsType.Exclude_keyofCreateOrderParamsType.fromExchange-or-toExchange-or-readonlyExchange-or-exchange__": {
         "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"amount":{"dataType":"string","required":true},"pairSymbol":{"dataType":"string","required":true},"orderSide":{"ref":"OrderSide","required":true},"price":{"dataType":"string","required":true},"orderType":{"ref":"OrderType","required":true},"metadata":{"dataType":"nestedObjectLiteral","nestedProperties":{"defiAddress":{"dataType":"string"},"tradeAndSend":{"dataType":"boolean"}}},"clientOrderId":{"dataType":"string"},"stp":{"ref":"OrderStpTypes"},"extraHeaders":{"ref":"Record_string.string_"}},"validators":{}},
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"amount":{"dataType":"string","required":true},"pairSymbol":{"dataType":"string","required":true},"orderSide":{"ref":"OrderSide","required":true},"price":{"dataType":"string","required":true},"orderType":{"ref":"OrderType","required":true},"recaptchaToken":{"dataType":"string"},"metadata":{"dataType":"nestedObjectLiteral","nestedProperties":{"defiAddress":{"dataType":"string"},"tradeAndSend":{"dataType":"boolean"}}},"clientOrderId":{"dataType":"string"},"stp":{"ref":"OrderStpTypes"},"extraHeaders":{"ref":"Record_string.string_"}},"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     "Omit_CreateOrderParamsType.fromExchange-or-toExchange-or-readonlyExchange-or-exchange_": {

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -851,6 +851,9 @@
 						},
 						"type": "object"
 					},
+					"recaptchaToken": {
+						"type": "string"
+					},
 					"amount": {
 						"type": "string"
 					},
@@ -1060,6 +1063,9 @@
 					},
 					"orderType": {
 						"$ref": "#/components/schemas/OrderType"
+					},
+					"recaptchaToken": {
+						"type": "string"
 					},
 					"metadata": {
 						"properties": {
@@ -2257,7 +2263,7 @@
 	},
 	"info": {
 		"title": "@cedelabs/sdk-http-api",
-		"version": "1.2.1",
+		"version": "1.3.1",
 		"license": {
 			"name": "MIT"
 		},

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@cedelabs/sdk-http-api",
-	"version": "1.2.1",
+	"version": "1.3.1",
 	"main": "dist/index.js",
 	"license": "MIT",
 	"type": "module",
@@ -11,7 +11,7 @@
 		"test": "vitest"
 	},
 	"dependencies": {
-		"@cedelabs-private/sdk": "2.19.2",
+		"@cedelabs-private/sdk": "2.21.0",
 		"body-parser": "^1.20.3",
 		"dotenv": "^16.4.5",
 		"express": "^4.21.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@cedelabs-private/sdk':
-        specifier: 2.19.2
-        version: 2.19.2
+        specifier: 2.21.0
+        version: 2.21.0
       body-parser:
         specifier: ^1.20.3
         version: 1.20.3
@@ -76,8 +76,8 @@ packages:
     resolution: {integrity: sha512-8Q/r5mXLa8Rfyh6r4SgEEFJgISVN5cDNFlcfSWLgFn3odzQhTfHAqzI3hMGdcROViL+8NrDNVVFQtEUrYOksDg==}
     engines: {node: '>= 16'}
 
-  '@cedelabs-private/sdk@2.19.2':
-    resolution: {integrity: sha512-MDeO4PMjUeLVqJ7ABObZtLpSj4B10/Ic0UaL+80olCfcXGbQBRtv6JppxGOGROJqbSO5a5pW8wbMDFWHrzZmUg==}
+  '@cedelabs-private/sdk@2.21.0':
+    resolution: {integrity: sha512-fIIXv6YssCHtH/CmFUJmDhyaq9LvMLMHP7giY6K2GKoVrQGcWslA1ACgICinx+sa2qbZ5oyblh1FV0wR/ylSMA==}
 
   '@colors/colors@1.6.0':
     resolution: {integrity: sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA==}
@@ -912,6 +912,9 @@ packages:
 
   '@types/node-forge@1.3.11':
     resolution: {integrity: sha512-FQx220y22OKNTqaByeBGqHWYz4cl94tpcxeFdvBo3wjG6XPBuZ0BNgNZRV5J5TFmmcsJ4IzsLkmGRiQbnYsBEQ==}
+
+  '@types/node-rsa@1.1.4':
+    resolution: {integrity: sha512-dB0ECel6JpMnq5ULvpUTunx3yNm8e/dIkv8Zu9p2c8me70xIRUUG3q+qXRwcSf9rN3oqamv4116iHy90dJGRpA==}
 
   '@types/node@22.13.1':
     resolution: {integrity: sha512-jK8uzQlrvXqEU91UxiK5J7pKHyzgnI1Qnl0QDHIgVGuolJhRb9EEl28Cj9b3rGR8B2lhFCtvIm5os8lFnO/1Ew==}
@@ -2166,11 +2169,12 @@ snapshots:
       '@types/json-schema': 7.0.15
       js-yaml: 4.1.0
 
-  '@cedelabs-private/sdk@2.19.2':
+  '@cedelabs-private/sdk@2.21.0':
     dependencies:
       '@types/chrome': 0.0.287
       '@types/lodash': 4.17.13
       '@types/node-forge': 1.3.11
+      '@types/node-rsa': 1.1.4
 
   '@colors/colors@1.6.0': {}
 
@@ -2853,6 +2857,10 @@ snapshots:
       '@types/express': 4.17.21
 
   '@types/node-forge@1.3.11':
+    dependencies:
+      '@types/node': 22.13.1
+
+  '@types/node-rsa@1.1.4':
     dependencies:
       '@types/node': 22.13.1
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,6 +32,7 @@ if (clientId === "" && env.MODE === "REAL") {
 }
 const secretApiKey = process.env.SECRET_API_KEY || "";
 const proxyUrl = process.env.PROXY_URL || "";
+const ipPoolSize = process.env.IP_POOL_SIZE ? parseInt(process.env.IP_POOL_SIZE) : 1;
 const verbose = process.env.VERBOSE as "vv" | "v" | undefined;
 
 logger.info(`SDK-API config: 
@@ -41,6 +42,7 @@ logger.info(`SDK-API config:
 	mode: ${env.MODE === "MOCK" ? "MOCK" : "REAL"},
 	clientId: ${clientId},
 	proxyUrl: ${proxyUrl},
+	ipPoolSize: ${ipPoolSize},
 	sdk-api authentication enabled: ${!secretApiKey ? "NO" : "YES"}
 	cache: ${getCache().constructor.name}
 	verbose: ${verbose ? "YES" : "NO"}
@@ -53,6 +55,7 @@ sdkApi({
 	clientId,
 	cache: getCache(),
 	proxyUrl,
+	ipPoolSize,
 	verbose,
 	authentication: !secretApiKey ? () => true : hmacAuthStrategyMiddleware({
 		secretKey: secretApiKey,

--- a/src/types.ts
+++ b/src/types.ts
@@ -46,6 +46,11 @@ export type SdkApiConfiguration = {
 	 */
 	proxyUrl?: string;
 	/**
+	 * The number of unique IPs in your proxy pool. This is used to scale the rate limits for exchanges
+	 * that limit by IP (like Binance). Default is 1.
+	 */
+	ipPoolSize?: number;
+	/**
 	 * Verbose mode.
 	 * 
 	 * - `"vv"`: Prints all network requests/responses and logs.

--- a/src/utils/sdk.ts
+++ b/src/utils/sdk.ts
@@ -8,6 +8,7 @@ export async function setupCedeSdk(configuration: SdkApiConfiguration) {
 	const sdk = new CedeSDK(configuration.mode, {
 		clientId: configuration.clientId,
 		proxyUrl: configuration.proxyUrl,
+		ipPoolSize: configuration.ipPoolSize,
 		cacheStorage: await configuration.cache,
 		verbose: configuration.verbose,
 		disableTelemetry: true,	

--- a/tsoa.json
+++ b/tsoa.json
@@ -14,7 +14,7 @@
     ],
     "info": {
       "title": "Cede SDK API",
-      "version": "1.2.1_sdk2.19.2"
+      "version": "1.3.1_sdk2.21.0"
     }
   },
   "routes": {


### PR DESCRIPTION
Introducing IP pool size configuration to linearly increase request throughput. If the value is greater than 1, you must use a round-robin strategy to assign IPs behind the proxy URL load balancer.